### PR TITLE
Replace `get_full_name` with `telethon.utils.get_display_name`

### DIFF
--- a/kantek/plugins/private/stats.py
+++ b/kantek/plugins/private/stats.py
@@ -1,10 +1,10 @@
 import logging
 import time
 
+from telethon.utils import get_display_name
 from telethon.tl.custom import Dialog
 from telethon.tl.types import Channel, Chat, User
 
-from kantek.utils import helpers
 from kantek import Client
 from kantex.md import *
 from kantek import k, Command
@@ -77,7 +77,7 @@ async def stats(client: Client, event: Command) -> KanTeXDocument:  # pylint: di
         unread += dialog.unread_count
     stop_time = time.time() - start_time
 
-    full_name = await helpers.get_full_name(await client.get_me())
+    full_name = get_display_name(await client.get_me())
     response = KanTeXDocument(
         Section(Bold(f'Stats for {full_name}')),
         Section('Private Chats',

--- a/kantek/plugins/private/user.py
+++ b/kantek/plugins/private/user.py
@@ -3,6 +3,7 @@ from typing import Union, Dict, List, Optional
 
 from kantex.md import *
 from spamwatch.types import Permission
+from telethon.utils import get_display_name
 from telethon.tl.custom import Forward, Message
 from telethon.tl.types import MessageEntityMention, MessageEntityMentionName, User, Channel
 
@@ -122,7 +123,7 @@ async def _collect_user_info(client, user, db, **kwargs) -> Union[str, Section, 
 
     mention_name = kwargs.get('mention', False)
 
-    full_name = await helpers.get_full_name(user)
+    full_name = get_display_name(user)
     if mention_name:
         title = Link(full_name, f'tg://user?id={user.id}')
     else:

--- a/kantek/utils/helpers.py
+++ b/kantek/utils/helpers.py
@@ -27,18 +27,6 @@ MESSAGE_LINK_PATTERN = re.compile(r't\.me/(?:c/)?(?P<chat>\w+)/(?P<id>\d+)')
 logger: logging.Logger = logzero.logger
 
 
-async def get_full_name(user: User) -> str:
-    """Return first_name + last_name if last_name exists else just first_name
-
-    Args:
-        user: The user
-
-    Returns:
-        The combined names
-    """
-    return f"{user.first_name or ''} {user.last_name or ''})"
-
-
 async def get_args(event: NewMessage.Event, skip: int = 1) -> Tuple[Dict[str, str], List[str]]:
     """Get arguments from a event
 


### PR DESCRIPTION
This also fixes the typo that adds the closing parentheses (introduced in https://github.com/kantek/kantek/commit/b713b20d68d30380c7707cf82d2ca7ba5e6835be).